### PR TITLE
Optimize Dockerfile for minimal image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY requirements.txt requirements.txt
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the code
 COPY . .


### PR DESCRIPTION
Leave no pip temporary cache in the Docker image 🎉 

```
REPOSITORY         TAG              IMAGE ID       CREATED              SIZE
After              latest           83e5f9d11a64   About a minute ago   74.3MB
Before             latest           0747a7ce2ed5   About a minute ago   78.6MB
```